### PR TITLE
feat: add cancel token support for API requests

### DIFF
--- a/packages/network/CHANGELOG.md
+++ b/packages/network/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.7
+### Added
+- **Cancel Token Support:** Added support for cancel tokens in API requests to allow for request cancellation.
+
+
 ## 0.0.6
 
 ### Changed

--- a/packages/network/lib/src/bond_fire/base_bond_api_request.dart
+++ b/packages/network/lib/src/bond_fire/base_bond_api_request.dart
@@ -25,6 +25,7 @@ class BaseBondApiRequest<T> {
   Map<String, dynamic>? _body;
   Map<String, File>? _files;
   Map<String, dynamic>? _data;
+  CancelToken? _cancelToken;
   Factory<T>? _factory;
   ErrorFactory? _errorFactory;
   final Map<String, String> _customCacheKeys = {};
@@ -61,6 +62,11 @@ class BaseBondApiRequest<T> {
     return this;
   }
 
+  BaseBondApiRequest<T> cancelToken(CancelToken cancelToken) {
+    _cancelToken = cancelToken;
+    return this;
+  }
+
   BaseBondApiRequest<T> factory(Factory<T> factory) {
     _factory = factory;
     return this;
@@ -89,6 +95,7 @@ class BaseBondApiRequest<T> {
           method: _method,
           headers: _headers,
         ),
+        cancelToken: _cancelToken,
       );
       if (_customCacheKeys.entries.isNotEmpty) {
         await _cacheCustomKeys(response.data);

--- a/packages/network/pubspec.yaml
+++ b/packages/network/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bond_network
 description: Network is a Bond package provides a convenient way to handle API response.
-version: 0.0.6
+version: 0.0.7
 homepage: https://github.com/onestudio-co/flutter-bond
 repository: https://github.com/onestudio-co/bond-core/tree/main/packages/network
 


### PR DESCRIPTION
Add a `cancelToken` method to the `BaseBondApiRequest` class to 
enable request cancellation. Update the API request method to 
include `cancelToken` in the request parameters. Increment the 
version to 0.0.7 and update the changelog to reflect the new 
feature.